### PR TITLE
Creating configured weight & bias matrices

### DIFF
--- a/services/pg/create_fun.pgsql
+++ b/services/pg/create_fun.pgsql
@@ -54,6 +54,13 @@ CREATE FUNCTION public.layer_activation(IN tick text, IN layer integer)
     
 AS $BODY$ SELECT ACT_TYPE FROM layers WHERE TICKER = tick AND LAYER_NUM = layer$BODY$;
 
+/* Create Get WB Function*/
+CREATE FUNCTION public.get_wb(IN tick text, IN ind integer)
+    RETURNS real
+    LANGUAGE 'sql'
+    
+AS $BODY$ SELECT VALUE FROM weights_biases WHERE TICKER = tick AND INDEX = ind$BODY$;
+
 /*
 
 Sample function usage

--- a/services/pg/insert_sample_data.pgsql
+++ b/services/pg/insert_sample_data.pgsql
@@ -4,7 +4,14 @@ INSERT INTO networks (TICKER, LAYERS) VALUES ('LMT', 2);
 
 /* Layers Table Sample Data Input */
 INSERT INTO layers (TICKER, LAYER_NUM, INPUTS, NODES, IND_START, LAYER_TYPE, ACT_TYPE)
-    VALUES('MSFT', 1, 4, 2, 1, 0, 2);
+    VALUES('MSFT', 1, 3, 2, 1, 0, 2);
 
 /* Weight & Biases Table Sample Data Input */
-INSERT INTO weights_biases (TICKER, INDEX, VALUE) VALUES ('MSFT', 1, 2.5);
+INSERT INTO weights_biases (TICKER, INDEX, VALUE) VALUES ('MSFT', 1, 1.5);
+INSERT INTO weights_biases (TICKER, INDEX, VALUE) VALUES ('MSFT', 2, 2.5);
+INSERT INTO weights_biases (TICKER, INDEX, VALUE) VALUES ('MSFT', 3, 3.5);
+INSERT INTO weights_biases (TICKER, INDEX, VALUE) VALUES ('MSFT', 4, 4.5);
+INSERT INTO weights_biases (TICKER, INDEX, VALUE) VALUES ('MSFT', 5, 5.5);
+INSERT INTO weights_biases (TICKER, INDEX, VALUE) VALUES ('MSFT', 6, 6.5);
+INSERT INTO weights_biases (TICKER, INDEX, VALUE) VALUES ('MSFT', 7, 7.5);
+INSERT INTO weights_biases (TICKER, INDEX, VALUE) VALUES ('MSFT', 8, 8.5);

--- a/trader/interfaces/pg_connect.cpp
+++ b/trader/interfaces/pg_connect.cpp
@@ -208,3 +208,19 @@ int PGConnect::pg2i(char* in) {
   // Convert to integer
   return atoi(in);
 }
+
+/*
+  Function:     pg2f
+  Inputs:       in (char*)
+  Outputs:      out (float)
+
+  Description:
+    Convert the postgres response character array into a float
+*/
+float PGConnect::pg2f(char* in) {
+  // Null check
+  if (!in) return 0;
+
+  // Convert to integer
+  return atof(in);
+}

--- a/trader/interfaces/pg_connect.h
+++ b/trader/interfaces/pg_connect.h
@@ -55,6 +55,7 @@ protected:
 
   // Common Conversions
   int pg2i(char* input);
+  float pg2f(char* input);
 
   // Postgres Connection
   PGconn* connection;

--- a/trader/interfaces/pg_layer.h
+++ b/trader/interfaces/pg_layer.h
@@ -19,6 +19,7 @@
 
 // Utility Includes
 #include "network_types.h"
+#include "matrix.h"
 
 class PGLayer : public PGConnect {
 public:
@@ -38,6 +39,8 @@ protected:
   int getInd(void);
   LayerTypes getLayerType(void);
   ActivationTypes getActivationType(void);
+  dMatrix getWeight(void);
+  dMatrix getBias(void);
 
 private:
   LayerConfiguration layerOut;

--- a/trader/tests/test_pg_layer.cc
+++ b/trader/tests/test_pg_layer.cc
@@ -14,6 +14,9 @@
 // Interface Includes
 #include "pg_layer.h"
 
+// Utility Includes
+#include "matrix.h"
+
 // Google Test Includes
 #include <gtest/gtest.h>
 
@@ -39,7 +42,7 @@ protected:
     Ensure expected results using the SQL "layer_inputs" function
 */
 TEST_F(PGLayerTest, Inputs) {
-  EXPECT_EQ(4, getInputs());
+  EXPECT_EQ(3, getInputs());
 }
 
 /*
@@ -79,6 +82,28 @@ TEST_F(PGLayerTest, ActivationType) {
 }
 
 /*
+  Test:         Weight
+  Description:
+    Ensure expected results using the SQL "get_wb" function
+*/
+TEST_F(PGLayerTest, Weight) {
+  dMatrix out = getWeight();
+  EXPECT_EQ(2, out.rows());
+  EXPECT_EQ(3, out.cols());
+}
+
+/*
+  Test:         Bias
+  Description:
+    Ensure expected results using the SQL "get_wb" function
+*/
+TEST_F(PGLayerTest, Bias) {
+  dMatrix out = getBias();
+  EXPECT_EQ(2, out.rows());
+  EXPECT_EQ(1, out.cols());
+}
+
+/*
   Test:         Configuration
   Description:
     Ensure expected results are formatted properly within the layer
@@ -87,9 +112,11 @@ TEST_F(PGLayerTest, ActivationType) {
 TEST_F(PGLayerTest, Configuration) {
   LayerConfiguration capture = getLayer("MSFT", 1);
 
-  EXPECT_EQ(4, capture.layerWidth);
+  EXPECT_EQ(3, capture.layerWidth);
   EXPECT_EQ(2, capture.layerHeight);
-  EXPECT_EQ(1, capture.offset);
   EXPECT_EQ(LayerTypes::FULLYCONNECTED, capture.Layer);
   EXPECT_EQ(ActivationTypes::RELU, capture.Activation);
+
+  EXPECT_DOUBLE_EQ(capture.weight(0, 1), 3.5);
+  EXPECT_DOUBLE_EQ(capture.bias(0, 0), 7.5);
 }

--- a/trader/util/network_types.h
+++ b/trader/util/network_types.h
@@ -54,14 +54,12 @@ struct LayerConfiguration {
   ActivationTypes Activation;
   size_t layerHeight;
   size_t layerWidth;
-  size_t offset;
   dMatrix weight;
   dMatrix bias;
 
   LayerConfiguration() :
     Layer(LayerTypes::UNKNOWN),
     Activation(ActivationTypes::LINEAR),
-    offset(0),
     layerHeight(0),
     layerWidth(0) {}
 };


### PR DESCRIPTION
Matrix sizing configuration obtained in previous update is used to determine the size of the current weights and biases. Entire layer configuration is passed through one struct member without the need of further configuration

Closes #53 